### PR TITLE
[RT-171] Add whole Date type param as a search filter

### DIFF
--- a/lib/factiva/request.rb
+++ b/lib/factiva/request.rb
@@ -21,7 +21,18 @@ module Factiva
       set_auth
     end
 
-    def search(first_name:, last_name:, birth_year: nil, birth_month: nil, birth_day: nil, offset: 0, limit: 200)
+    def search(first_name:, last_name:, birth_date: nil, birth_year: nil,
+               birth_month: nil, birth_day: nil, offset: 0, limit: 200)
+
+      # Birth date takes priority over year, month and day values
+      if birth_date
+        birth_year, birth_month, birth_day = [
+          birth_date.year.to_s,
+          birth_date.month.to_s,
+          birth_date.day.to_s
+        ]
+      end
+
       params = { json: search_body(
         first_name,
         last_name,

--- a/spec/factiva/request_spec.rb
+++ b/spec/factiva/request_spec.rb
@@ -29,20 +29,56 @@ module Factiva
         end
 
         context "filtering by date" do
-          let(:params) do
-            {
-              first_name: "Jhon",
-              last_name: "Smith",
-              birth_year: "1992",
-              birth_month: "12",
-              birth_day: "22"
-            }
+          context "using year, month and day option", vcr: "search/filter_by_date" do
+            let(:params) do
+              {
+                first_name: "Jhon",
+                last_name: "Smith",
+                birth_year: "1992",
+                birth_month: "12",
+                birth_day: "22"
+              }
+            end
+
+            it "returns search info" do
+              response = subject.search(params)
+              expect(response["meta"]["total_count"]).to eq(47)
+              expect(response["data"][0]["type"]).to eq("RiskEntities")
+            end
           end
 
-          it "returns search info", vcr: "search/filter_by_date" do
-            response = subject.search(params)
-            expect(response["meta"]["total_count"]).to eq(47)
-            expect(response["data"][0]["type"]).to eq("RiskEntities")
+          context "using birthdate option", vcr: "search/filter_by_date" do
+            let(:params) do
+              {
+                first_name: "Jhon",
+                last_name: "Smith",
+                birth_date: Date.new(1992, 12, 22)
+              }
+            end
+
+            it "returns search info" do
+              response = subject.search(params)
+              expect(response["meta"]["total_count"]).to eq(47)
+              expect(response["data"][0]["type"]).to eq("RiskEntities")
+            end
+          end
+
+          context "using both options", vcr: "search/filter_by_date" do
+            let(:params) do
+              {
+                first_name: "Jhon",
+                last_name: "Smith",
+                birth_date: Date.new(1992, 12, 22),
+                birth_year: "1980",
+                birth_month: "5",
+                birth_day: "11"
+              }
+            end
+            it "takes birthdate as priority and returns search info" do
+              response = subject.search(params)
+              expect(response["meta"]["total_count"]).to eq(47)
+              expect(response["data"][0]["type"]).to eq("RiskEntities")
+            end
           end
         end
 


### PR DESCRIPTION
 ### What is the goal?
To be able to pass a `Date` type param to #search method, so the app using this library does not have to parse and split a date into three variables (year, month, day)

 ### References
* **Related pull-requests:** https://sequra.atlassian.net/browse/RT-171

 ### Definition of done

1. [ ] Add new optional parameter to search method
1. [ ] Use this parameter as a priority over year, month and day variables.

 ### How is it being implemented?
Parameter added and, if the parameter is used, it overrides the date to filter by in the request body.

 ### How is it tested?
Automatic tests
