### PR TITLE
[DX-32] Add github actions for spec, release and rubocop

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,34 @@
+name: Create release pull request
+on:
+  push:
+    branches:
+      - 'master'
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: GoogleCloudPlatform/release-please-action@v3
+        id: release
+        with:
+          release-type: ruby
+          package-name: i18n-toolkit
+          bump-minor-pre-major: true
+          version-file: 'lib/i18n_toolkit/version.rb'
+      - uses: actions/checkout@v2
+        if: ${{ steps.release.outputs.release_created }}
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.1'
+        if: ${{ steps.release.outputs.release_created }}
+      - name: Publish gem to Github repostiory packages
+        run: |
+          mkdir -p $HOME/.gem
+          touch $HOME/.gem/credentials
+          chmod 0600 $HOME/.gem/credentials
+          printf -- "---\n:github: ${GEM_HOST_API_KEY}\n" > $HOME/.gem/credentials
+          gem build *.gemspec
+          gem push --KEY github --host https://rubygems.pkg.github.com/${OWNER} *.gem
+        env:
+          GEM_HOST_API_KEY: "Bearer ${{secrets.GITHUB_TOKEN}}"
+          OWNER: ${{ github.repository_owner }}
+        if: ${{ steps.release.outputs.release_created }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,9 +11,9 @@ jobs:
         id: release
         with:
           release-type: ruby
-          package-name: i18n-toolkit
+          package-name: factiva-api-client
           bump-minor-pre-major: true
-          version-file: 'lib/i18n_toolkit/version.rb'
+          version-file: 'lib/factiva/version.rb'
       - uses: actions/checkout@v2
         if: ${{ steps.release.outputs.release_created }}
       - uses: ruby/setup-ruby@v1

--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -1,0 +1,28 @@
+name: Run gem static analysis
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+jobs:
+  rubocop:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - run: |
+        git fetch --no-tags --prune origin
+    - name: Set up Ruby 3.1
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: '3.1'
+        bundler-cache: true
+        cache-version: 1
+    - name: rubocop
+      uses: reviewdog/action-rubocop@v2
+      with:
+        use_bundler: true
+        reporter: github-pr-review
+        filter_mode: file
+        fail_on_error: true
+        

--- a/.github/workflows/specs.yml
+++ b/.github/workflows/specs.yml
@@ -1,0 +1,20 @@
+name: Run url_shortener-client gem specs
+on:
+  push:
+    branches:
+      - "**" # matches every branch
+      - '!master' # excludes master
+jobs:
+  run-specs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 3.1
+          bundler-cache: true
+          cache-version: 1
+      - name: Run tests
+        run: |
+          bundle exec rspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -121,6 +121,7 @@ GEM
 
 PLATFORMS
   ruby
+  x86_64-linux
 
 DEPENDENCIES
   factiva-api-client!


### PR DESCRIPTION
 ### What is the goal?
 
Get a Rubocop runner on a gem repository using GitHub Actions.

 ### References

CI improvements. https://sequra.atlassian.net/browse/DX-32

 ### How is it being implemented?

Adding the sequra rubocop configuration, yaml config files and a Reviewdog action to run it
Adding the actions to run tests and create/release the packages for the gem

 ### Does the change affect accounting?

no

 ### Does it affect anything sensitive for Findirect?

no

 ### Opportunistic refactorings

no

 ### Caveats

no

 ### How is it tested?

auto

 ### How is it going to be deployed?

sd