### PR TITLE
[RT-749] Raise HTTP::TimeoutError for CircuitBreaker

### DIFF
--- a/lib/factiva.rb
+++ b/lib/factiva.rb
@@ -1,7 +1,6 @@
 Dir[File.join(__dir__, "factiva", "*.rb")].each { |file| require file }
 
 module Factiva
-
   REQUEST_API_ACCOUNT = "request_api_account"
   MONITORING_API_ACCOUNT = "monitoring_api_account"
 

--- a/lib/factiva/client.rb
+++ b/lib/factiva/client.rb
@@ -26,6 +26,8 @@ module Factiva
         .value_or { |error| raise RequestError.new(error) }
     end
 
+  private
+
     def make_request(http_method, url, params = nil)
       http_params = [http_method, url, params].compact
 

--- a/lib/factiva/client.rb
+++ b/lib/factiva/client.rb
@@ -1,0 +1,60 @@
+require "dry/monads"
+
+module Factiva
+  class Client
+    include Dry::Monads[:result]
+
+    attr_reader :config, :auth
+
+    def initialize(config)
+      @config = config
+      @auth = nil
+    end
+
+    def set_auth!
+      @auth = Authentication.new(config)
+    end
+
+    def make_authorized_request(...)
+      make_request(...)
+        .or       { set_auth!; make_request(...) }
+        .value_or { |error| raise RequestError.new(error) }
+    end
+
+    def make_authentication_request(...)
+      make_request(...)
+        .value_or { |error| raise RequestError.new(error) }
+    end
+
+    def make_request(http_method, url, params = nil)
+      http_params = [http_method, url, params].compact
+
+      begin
+        request = HTTP
+          .headers(:accept => "application/json")
+          .headers("Content-Type" => "application/json")
+          .timeout(config.timeout)
+
+        request.auth("Bearer #{auth.token}") if auth
+
+        response = request.send(*http_params)
+
+        response_body = JSON.parse(response.body.to_s)
+
+        if response.status.success?
+          Success(response_body)
+        else
+          Failure({ code: response.code, error: response_body["error"] }.to_s)
+        end
+      rescue HTTP::TimeoutError
+        # This error should be handled before HTTP::Error which is a superclass of HTTP::TimeoutError
+        # Raising HTTP::TimeoutError is required for CircuitBreaker to work properly
+        raise
+      rescue SocketError, HTTP::Error => error
+        Failure("Failed to connect to Factiva: #{error.message}")
+      rescue JSON::ParserError => error
+        Failure(error.message)
+      end
+    end
+  end
+end

--- a/lib/factiva/client.rb
+++ b/lib/factiva/client.rb
@@ -50,8 +50,8 @@ module Factiva
         end
       rescue HTTP::TimeoutError
         # This error should be handled before HTTP::Error which is a superclass of HTTP::TimeoutError
-        # Raising HTTP::TimeoutError is required for CircuitBreaker to work properly
-        raise
+        # Raising Factiva::TimeoutError is required for CircuitBreaker to work properly
+        raise Factiva::TimeoutError
       rescue SocketError, HTTP::Error => error
         Failure("Failed to connect to Factiva: #{error.message}")
       rescue JSON::ParserError => error

--- a/lib/factiva/errors.rb
+++ b/lib/factiva/errors.rb
@@ -1,3 +1,5 @@
 module Factiva
-  class RequestError < StandardError; end
+  class Error < StandardError; end
+  class RequestError < Error; end
+  class TimeoutError < Error; end
 end

--- a/lib/factiva/monitoring.rb
+++ b/lib/factiva/monitoring.rb
@@ -3,15 +3,15 @@ require "json"
 
 module Factiva
   class Monitoring
-    private_class_method :new
-    attr_reader :client
-
     COUNTRY_IDS = {
       "ES" => "SPAIN",
       "FR" => "FRA",
       "IT" => "ITALY",
       "PT" => "PORL",
     }.freeze
+
+    private_class_method :new
+    attr_reader :client
 
     def self.create_case(**args)
       instance.create_case(**args)
@@ -71,9 +71,9 @@ module Factiva
         stubbed_get_matches,
         stubbed_log_decision
       )
-        @stubbed_create_case  = stubbed_create_case
-        @stubbed_create_association  = stubbed_create_association
-        @stubbed_add_association_to_case  = stubbed_add_association_to_case
+        @stubbed_create_case = stubbed_create_case
+        @stubbed_create_association = stubbed_create_association
+        @stubbed_add_association_to_case = stubbed_add_association_to_case
         @stubbed_get_matches = stubbed_get_matches
         @stubbed_log_decision = stubbed_log_decision
       end
@@ -111,7 +111,7 @@ module Factiva
 
     def create_association(first_name:, last_name:, birth_year:, external_id:, nin:, country_code:)
       params = { json: association_body(
-          first_name,
+        first_name,
           last_name,
           birth_year,
           external_id,
@@ -125,7 +125,7 @@ module Factiva
 
     def add_association_to_case(case_id:, association_id:)
       params = { json: case_association_body(
-          association_id,
+        association_id,
         )
       }
 
@@ -138,7 +138,7 @@ module Factiva
 
     def log_decision(case_id:, match_id:, comment:, state:, risk_rating:)
       params = { json: log_decision_body(
-          comment, state, risk_rating,
+        comment, state, risk_rating,
         )
       }
 

--- a/lib/factiva/monitoring.rb
+++ b/lib/factiva/monitoring.rb
@@ -202,6 +202,10 @@ module Factiva
         else
           Failure({ code: response.code, error: response_body["error"] }.to_s)
         end
+      rescue HTTP::TimeoutError
+        # This error should be handled before HTTP::Error which is a superclass of HTTP::TimeoutError
+        # Raising HTTP::TimeoutError is required for CircuitBreaker to work properly
+        raise
       rescue SocketError, HTTP::Error => error
         Failure("Failed to connect to Factiva: #{error.message}")
       rescue JSON::ParserError => error

--- a/lib/factiva/monitoring.rb
+++ b/lib/factiva/monitoring.rb
@@ -13,24 +13,24 @@ module Factiva
     private_class_method :new
     attr_reader :client
 
-    def self.create_case(**args)
-      instance.create_case(**args)
+    def self.create_case(...)
+      instance.create_case(...)
     end
 
-    def self.create_association(**args)
-      instance.create_association(**args)
+    def self.create_association(...)
+      instance.create_association(...)
     end
 
-    def self.add_association_to_case(**args)
-      instance.add_association_to_case(**args)
+    def self.add_association_to_case(...)
+      instance.add_association_to_case(...)
     end
 
-    def self.get_matches(**args)
-      instance.get_matches(**args)
+    def self.get_matches(...)
+      instance.get_matches(...)
     end
 
-    def self.log_decision(**args)
-      instance.log_decision(**args)
+    def self.log_decision(...)
+      instance.log_decision(...)
     end
 
     def self.reset_auth
@@ -78,23 +78,23 @@ module Factiva
         @stubbed_log_decision = stubbed_log_decision
       end
 
-      def create_case(**args)
+      def create_case(...)
         stubbed_create_case
       end
 
-      def create_association(**args)
+      def create_association(...)
         stubbed_create_association
       end
 
-      def add_association_to_case(**args)
+      def add_association_to_case(...)
         stubbed_add_association_to_case
       end
 
-      def get_matches(**args)
+      def get_matches(...)
         stubbed_get_matches
       end
 
-      def log_decision(**args)
+      def log_decision(...)
         stubbed_log_decision
       end
     end

--- a/lib/factiva/request.rb
+++ b/lib/factiva/request.rb
@@ -119,6 +119,10 @@ module Factiva
         else
           Failure({ code: response.code, error: response_body["error"] }.to_s)
         end
+      rescue HTTP::TimeoutError
+        # This error should be handled before HTTP::Error which is a superclass of HTTP::TimeoutError
+        # Raising HTTP::TimeoutError is required for CircuitBreaker to work properly
+        raise
       rescue SocketError, HTTP::Error => error
         Failure("Failed to connect to Factiva: #{error.message}")
       rescue JSON::ParserError => error

--- a/spec/factiva/authentication_spec.rb
+++ b/spec/factiva/authentication_spec.rb
@@ -11,7 +11,7 @@ module Factiva
       context "Factiva responds as expected", vcr: { cassette_name: "authentication/first_time_authenticating/ok" } do
         it "returns token" do
           # Two requests: Get authn and Get authz
-          expect(HTTP).to receive(:timeout).twice.and_call_original
+          expect(subject.client).to receive(:make_request).twice.and_call_original
           expect(subject.token).to eq(
             "eyJhbGciOiJSUzI1NiIsImtpZCI6IjJEN0IwQTFERkJCNzlDRDFBQjM4NzNCMTcyODMyRjkxME"\
             "NEQkRBREIiLCJ0eXAiOiJKV1QifQ.eyJwaWIiOnsiYXBjIjoiUk5DIiwiY3RjIjoiUCIsIm1hc"\
@@ -36,7 +36,7 @@ module Factiva
       context "retrieve authn token fails", vcr: { cassette_name: "authentication/first_time_authenticating/authn_fails" } do
         it "raises an exception" do
           # One request: Get authn
-          expect(HTTP).to receive(:timeout).once.and_call_original
+          expect(subject.client).to receive(:make_request).once.and_call_original
           expect {
             subject.token
           }.to raise_error(RequestError, { code: 403, error: "unauthorized_client" }.to_s)
@@ -46,7 +46,7 @@ module Factiva
       context "retrieve authz token fails", vcr: { cassette_name: "authentication/first_time_authenticating/authz_fails" } do
         it "raises an exception" do
           # Two requests: Get authn and Get authz
-          expect(HTTP).to receive(:timeout).twice.and_call_original
+          expect(subject.client).to receive(:make_request).twice.and_call_original
           expect {
             subject.token
           }.to raise_error(RequestError, { code: 400, error: "request_validation_error" }.to_s)
@@ -109,7 +109,7 @@ module Factiva
         context "Factiva responds as expected", vcr: { cassette_name: "authentication/token_expired/ok" } do
           it "refreshes the token" do
             # One request: Refresh authz
-            expect(HTTP).to receive(:timeout).once.and_call_original
+            expect(subject.client).to receive(:make_request).once.and_call_original
             expect(subject.token).to eq(
               "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6Ik4wSTJRekJEUWpRM04wUkJSakJF"\
               "UkRVM05qaEZNREF5T0VWRlJqWkRSVVl4TWtFMU5ERXdSUSJ9.eyJzZXJ2aWNlX2FjY291bnR"\
@@ -129,7 +129,7 @@ module Factiva
         context "Refresh token request fails", vcr: { cassette_name: "authentication/token_expired/refresh_authz_fails" } do
           it "raises an exception" do
             # One request: Refresh authz
-            expect(HTTP).to receive(:timeout).once.and_call_original
+            expect(subject.client).to receive(:make_request).once.and_call_original
             expect {
               subject.token
             }.to raise_error(RequestError, { code: 400, error: "invalid_request" }.to_s)

--- a/spec/factiva/authentication_spec.rb
+++ b/spec/factiva/authentication_spec.rb
@@ -58,8 +58,8 @@ module Factiva
           WebMock.stub_request(:post, /oauth2\/v1\/token/).to_timeout
         end
 
-        it "raises HTTP::TimeoutError for CircuitBreaker" do
-          expect { subject.token }.to raise_error(HTTP::TimeoutError)
+        it "raises Factiva::TimeoutError for CircuitBreaker" do
+          expect { subject.token }.to raise_error(Factiva::TimeoutError)
         end
       end
     end

--- a/spec/factiva/authentication_spec.rb
+++ b/spec/factiva/authentication_spec.rb
@@ -52,6 +52,16 @@ module Factiva
           }.to raise_error(RequestError, { code: 400, error: "request_validation_error" }.to_s)
         end
       end
+
+      context "Factiva connection timed out" do
+        before do
+          WebMock.stub_request(:post, /oauth2\/v1\/token/).to_timeout
+        end
+
+        it "raises HTTP::TimeoutError for CircuitBreaker" do
+          expect { subject.token }.to raise_error(HTTP::TimeoutError)
+        end
+      end
     end
 
     context "Already authenticated" do

--- a/spec/factiva/monitoring_spec.rb
+++ b/spec/factiva/monitoring_spec.rb
@@ -172,10 +172,10 @@ module Factiva
           WebMock.stub_request(:get, /risk-entity-screening-cases/).to_timeout
         end
 
-        it "raises HTTP::TimeoutError for CircuitBreaker" do
+        it "raises Factiva::TimeoutError for CircuitBreaker" do
           expect {
             subject.get_matches(case_id: "id")
-          }.to raise_error(HTTP::TimeoutError)
+          }.to raise_error(Factiva::TimeoutError)
         end
       end
     end

--- a/spec/factiva/monitoring_spec.rb
+++ b/spec/factiva/monitoring_spec.rb
@@ -174,7 +174,7 @@ module Factiva
 
         it "raises HTTP::TimeoutError for CircuitBreaker" do
           expect {
-            subject.get_matches({ case_id: "id" })
+            subject.get_matches(case_id: "id")
           }.to raise_error(HTTP::TimeoutError)
         end
       end

--- a/spec/factiva/monitoring_spec.rb
+++ b/spec/factiva/monitoring_spec.rb
@@ -86,7 +86,8 @@ module Factiva
         }
       }
 
-      context "when there isn't matches in the Case", vcr: "monitoring/no_matches" do # this VCR was recorded when there wasn't any match
+      # this VCR was recorded when there wasn't any match
+      context "when there isn't matches in the Case", vcr: "monitoring/no_matches" do
         let(:case_id) { "91473caa-9eb8-4eb1-891d-bde3d7c80cdd" }
 
         it "authenticates and doesn't get matches" do
@@ -96,7 +97,6 @@ module Factiva
       end
 
       context "when there are matches in the Case", vcr: "monitoring/matches" do
-
         let(:case_id) { "296373b3-80ee-4fb7-9f2e-b43604051c0b" }
 
         it "authenticates and returns 2 matches: 1 valid and 1 invalid" do
@@ -106,23 +106,23 @@ module Factiva
           invalid_match = {
             "peid" => "1003410",
             "type" => "RELATIONSHIP",
-            "variation" => {"structural" => false, "linguistic" => false, "non_linguistic" => false},
+            "variation" => { "structural" => false, "linguistic" => false, "non_linguistic" => false },
             "title" => "OFAC - Principal Significant Foreign Narcotics Trafficker List",
             "match_id" => "239b4a188aff307a328984b0129dbb3a1fd5a9e9385e664fb3091fcce67ecd17",
             "match_name" => "Maria Remedios Garcia Albert",
             "match_type" => "PRECISE",
-            "percentage_match" =>1.0,
+            "percentage_match" => 1.0,
             "subscription_name" => "Maria Remedios Garcia Albert",
-            "boosting_events" =>[],
+            "boosting_events" => [],
             "icon_hints" => ["SAN-PERSON", "SI-PERSON"],
             "primary_country" => "SPAIN",
             "is_score_boosted" => false,
-            "current_state" => {"timestamp" => "2022-06-22T07:41:53", "state" => "OPEN"},
-            "birthdates" => [{"day" => 17, "year" => 1951, "month" => 2}],
+            "current_state" => { "timestamp" => "2022-06-22T07:41:53", "state" => "OPEN" },
+            "birthdates" => [{ "day" => 17, "year" => 1951, "month" => 2 }],
             "gender" => "FEMALE",
             "is_deceased" => false,
             "match_date" => "2022-06-22T07:41:53",
-            "primary_name" => {"name_type" => "PRIMARY", "first_name" => "Maria Remedios", "last_name" => "Garcia Albert"},
+            "primary_name" => { "name_type" => "PRIMARY", "first_name" => "Maria Remedios", "last_name" => "Garcia Albert" },
             "has_alerts" => false,
             "is_match_valid" => false,
             "match_invalid_date" => "2022-06-22T07:41:53.349",
@@ -132,7 +132,7 @@ module Factiva
           valid_match = {
             "peid" => "1003410",
             "type" => "RELATIONSHIP",
-            "variation" => {"structural"=>false, "linguistic"=>false, "non_linguistic"=>false},
+            "variation" => { "structural" => false, "linguistic" => false, "non_linguistic" => false },
             "title" => "OFAC - Principal Significant Foreign Narcotics Trafficker List",
             "match_id" => "5e7a91388deea1e1368937aaa00c69635890f51e964909eb1f4daccf2ee69ca5",
             "match_name" => "Maria Remedios Garcia Albert",
@@ -143,12 +143,12 @@ module Factiva
             "icon_hints" => ["SAN-PERSON", "SI-PERSON"],
             "primary_country" => "SPAIN",
             "is_score_boosted" => false,
-            "current_state" => {"timestamp" => "2022-06-22T07:41:54", "state" => "OPEN"},
-            "birthdates" => [{"day"=>17, "year"=>1951, "month"=>2}],
+            "current_state" => { "timestamp" => "2022-06-22T07:41:54", "state" => "OPEN" },
+            "birthdates" => [{ "day" => 17, "year" => 1951, "month" => 2 }],
             "gender" => "FEMALE",
             "is_deceased" => false,
             "match_date" => "2022-06-22T07:41:54",
-            "primary_name" => {"name_type" => "PRIMARY", "first_name" => "Maria Remedios", "last_name" => "Garcia Albert"},
+            "primary_name" => { "name_type" => "PRIMARY", "first_name" => "Maria Remedios", "last_name" => "Garcia Albert" },
             "has_alerts" => true,
             "is_match_valid" => true,
           }.freeze
@@ -156,7 +156,8 @@ module Factiva
           expect(result["data"][0]["attributes"]["external_id"]).to eq("id-XXXXXXX")
           expect(result["data"][0]["attributes"]["matches"][0]["subscription_name"]).to eq("Maria Remedios Garcia Albert")
           expect(result["data"][0]["attributes"]["matches"][0]["is_match_valid"]).to be_falsey
-          expect(result["data"][0]["attributes"]["matches"][0]["match_invalid_reason"]).to eq "Match excluded by filter: year_of_birth"
+          expect(result["data"][0]["attributes"]["matches"][0]["match_invalid_reason"])
+            .to eq "Match excluded by filter: year_of_birth"
           expect(result["data"][0]["attributes"]["matches"][0]).to eq(invalid_match)
 
           expect(result["data"][1]["attributes"]["external_id"]).to eq("id1234")
@@ -193,7 +194,8 @@ module Factiva
       it "authenticates and Logs a decision to a Match" do
         res = subject.log_decision(**sample_data)
 
-        expect(res["data"]["attributes"]["current_state"]).to eq({"timestamp"=>"2022-06-21T10:04:37.645", "comment"=>"False positive", "state"=>"CLEARED", "risk_rating"=>1})
+        expect(res["data"]["attributes"]["current_state"]).to eq({ "timestamp" => "2022-06-21T10:04:37.645",
+"comment" => "False positive", "state" => "CLEARED", "risk_rating" => 1 })
       end
     end
   end

--- a/spec/factiva/monitoring_spec.rb
+++ b/spec/factiva/monitoring_spec.rb
@@ -165,6 +165,18 @@ module Factiva
           expect(result["data"][1]["attributes"]["matches"][0]).to eq(valid_match)
         end
       end
+
+      context "Factiva connection timed out", vcr: "monitoring/authentication_only" do
+        before do
+          WebMock.stub_request(:get, /risk-entity-screening-cases/).to_timeout
+        end
+
+        it "raises HTTP::TimeoutError for CircuitBreaker" do
+          expect {
+            subject.get_matches({ case_id: "id" })
+          }.to raise_error(HTTP::TimeoutError)
+        end
+      end
     end
 
     describe "#log_decision", vcr: "monitoring/log_decision" do

--- a/spec/factiva/request_spec.rb
+++ b/spec/factiva/request_spec.rb
@@ -120,6 +120,18 @@ module Factiva
           }.to raise_error(RequestError, "Failed to connect to Factiva: SocketError")
         end
       end
+
+      context "Factiva connection timed out", vcr: "search/authentication_only" do
+        before do
+          WebMock.stub_request(:post, /riskentities\/search/).to_timeout
+        end
+
+        it "raises HTTP::TimeoutError for CircuitBreaker" do
+          expect {
+            subject.search(**params)
+          }.to raise_error(HTTP::TimeoutError)
+        end
+      end
     end
 
     context "#Profile" do
@@ -164,6 +176,18 @@ module Factiva
           expect {
             subject.profile(profile_id)
           }.to raise_error(RequestError, "Failed to connect to Factiva: SocketError")
+        end
+      end
+
+      context "Factiva connection timed out", vcr: "profile/authentication_only" do
+        before do
+          WebMock.stub_request(:get, /riskentities\/profiles/).to_timeout
+        end
+
+        it "raises HTTP::TimeoutError for CircuitBreaker" do
+          expect {
+            subject.profile(profile_id)
+          }.to raise_error(HTTP::TimeoutError)
         end
       end
     end

--- a/spec/factiva/request_spec.rb
+++ b/spec/factiva/request_spec.rb
@@ -126,10 +126,10 @@ module Factiva
           WebMock.stub_request(:post, /riskentities\/search/).to_timeout
         end
 
-        it "raises HTTP::TimeoutError for CircuitBreaker" do
+        it "raises Factiva::TimeoutError for CircuitBreaker" do
           expect {
             subject.search(**params)
-          }.to raise_error(HTTP::TimeoutError)
+          }.to raise_error(Factiva::TimeoutError)
         end
       end
     end
@@ -184,10 +184,10 @@ module Factiva
           WebMock.stub_request(:get, /riskentities\/profiles/).to_timeout
         end
 
-        it "raises HTTP::TimeoutError for CircuitBreaker" do
+        it "raises Factiva::TimeoutError for CircuitBreaker" do
           expect {
             subject.profile(profile_id)
-          }.to raise_error(HTTP::TimeoutError)
+          }.to raise_error(Factiva::TimeoutError)
         end
       end
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,4 +14,8 @@ RSpec.configure do |config|
   config.expect_with :rspec do |c|
     c.syntax = :expect
   end
+
+  config.after(:each) do
+    WebMock.reset!
+  end
 end

--- a/spec/support/vcr_setup.rb
+++ b/spec/support/vcr_setup.rb
@@ -13,5 +13,6 @@ VCR.configure do |c|
   c.filter_sensitive_data("<SECRET_USERNAME>") { URI.encode_www_form_component(Factiva.configuration.username) }
   c.filter_sensitive_data("<SECRET_CLIENT_ID>") { Factiva.configuration(Factiva::MONITORING_API_ACCOUNT).client_id }
   c.filter_sensitive_data("<SECRET_PASSWORD>") { Factiva.configuration(Factiva::MONITORING_API_ACCOUNT).password }
-  c.filter_sensitive_data("<SECRET_USERNAME>") { URI.encode_www_form_component(Factiva.configuration(Factiva::MONITORING_API_ACCOUNT).username) }
+  c.filter_sensitive_data("<SECRET_USERNAME>") {
+ URI.encode_www_form_component(Factiva.configuration(Factiva::MONITORING_API_ACCOUNT).username) }
 end

--- a/spec/vcr/monitoring/authentication_only.yml
+++ b/spec/vcr/monitoring/authentication_only.yml
@@ -1,0 +1,156 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://accounts.dowjones.com/oauth2/v1/token
+    body:
+      encoding: UTF-8
+      string: client_id=<SECRET_CLIENT_ID>&connection=service-account&grant_type=password&password=<SECRET_PASSWORD>&scope=openid+service_account_id+offline_access%3A&username=<SECRET_USERNAME>&device=testdevice
+    headers:
+      Connection:
+      - close
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Host:
+      - accounts.dowjones.com
+      User-Agent:
+      - http.rb/5.1.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '873'
+      Connection:
+      - close
+      Access-Control-Allow-Methods:
+      - POST, GET, OPTIONS
+      Access-Control-Allow-Origin:
+      - "*"
+      Date:
+      - Wed, 22 Jun 2022 07:47:23 GMT
+      Server:
+      - Apache
+      Set-Cookie:
+      - djcs_route=76fc7bb7-f551-4e6f-8a3e-c5f63f96be7f; domain=.dowjones.com; path=/;
+        Expires=Sat Jun 19 07:47:23 2032; max-age=315360000;Secure; SameSite=none
+      X-P-Cache-Control:
+      - no-store
+      X-P-Connection:
+      - keep-alive
+      X-P-Content-Length:
+      - '873'
+      X-P-Content-Type:
+      - application/json; charset=utf-8
+      X-P-Date:
+      - Wed, 22 Jun 2022 07:47:23 GMT
+      X-P-P3p:
+      - CP="CAO DSP COR CURa ADMa DEVi TAIo PSAa PSDa IVDi CONi OTPi OUR OTRi BUS
+        PHY ONL UNI PUR COM NAV INT DEM CNT STA OTC"
+      X-P-Pragma:
+      - no-cache
+      X-P-Server:
+      - Microsoft-IIS/8.5
+      X-P-Via:
+      - 1.1 adb1632aa800f446f3f4e7b45c9dfd3e.cloudfront.net (CloudFront)
+      X-P-X-Amz-Cf-Id:
+      - cFsWb5PSIemUXKqN0oNEtJagitdH0EevR6brAIwFZ1iych834FXlcw==
+      X-P-X-Amz-Cf-Pop:
+      - IAD89-P2
+      X-P-X-Cache:
+      - Miss from cloudfront
+      X-P-X-Powered-By:
+      - ASP.NET
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 c0e2ae682a5570bf4332731523d68828.cloudfront.net (CloudFront)
+      X-Amz-Cf-Pop:
+      - LIS50-C1
+      X-Amz-Cf-Id:
+      - 4hJ8EPIkr08RRDx8QnwfhyRY0JLqHem2XdE5orWcHHr4hPA_704o8w==
+    body:
+      encoding: UTF-8
+      string: '{"id_token":"eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6Ik4wSTJRekJEUWpRM04wUkJSakJFUkRVM05qaEZNREF5T0VWRlJqWkRSVVl4TWtFMU5ERXdSUSJ9.eyJzZXJ2aWNlX2FjY291bnRfaWQiOiI5U0VRMDAwMzAwIiwiaXNzIjoiaHR0cHM6Ly9hdXRoLmFjY291bnRzLmRvd2pvbmVzLmNvbS8iLCJzdWIiOiJhdXRoMHw2MmE4ZGU5NzEwOGVjZTViODgxYWQxMmMiLCJhdWQiOiJ0emVXSmhhMVc1TndyVUJSQ1N3T2R0Q0dxSVE1bXpBSSIsImlhdCI6MTY1NTg4NDA0MywiZXhwIjoxNjU1OTIwMDQzfQ.fQ4LVRmMaqVRk1y5U37FCGkMz1CPMSsqOS7SSxxncpn0298pzSsH4MabbPOwzjmJ5pOJIJUgj2nHNmgLbRFH94xuWae40aENoWNxsp53UM1g9CTBGbUYj1ErxGmOQutw5yDR4ZFAjni3Lhj6s9pcvRFshNa0nDVtoOh53rz5NBfsN4kGNMUR31xyTPmlCZIbyJ2d3nR2vQv-OEbknoBQ9sBFxWwWkrTYjyZ28w6VGyAH2zC06zKSNgoMbC9GuXYoH5C8RXOu0EOcF6Q01mUABosGwOwJ02cg1DthIBssJ6BAkyegkQHupSXb5FZ45Z3Zwh16MZD_ig8oVi64-573bA","access_token":"SvXvu7ftOhw5UaMzhuHAQrqCZskUn3Wp","refresh_token":"GjZC_up_ctheOU6B2_eouvhq8LyLEtqBdFewcDbUUU6po","token_type":"bearer"}'
+  recorded_at: Wed, 22 Jun 2022 07:47:23 GMT
+- request:
+    method: post
+    uri: https://accounts.dowjones.com/oauth2/v1/token
+    body:
+      encoding: UTF-8
+      string: assertion=eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6Ik4wSTJRekJEUWpRM04wUkJSakJFUkRVM05qaEZNREF5T0VWRlJqWkRSVVl4TWtFMU5ERXdSUSJ9.eyJzZXJ2aWNlX2FjY291bnRfaWQiOiI5U0VRMDAwMzAwIiwiaXNzIjoiaHR0cHM6Ly9hdXRoLmFjY291bnRzLmRvd2pvbmVzLmNvbS8iLCJzdWIiOiJhdXRoMHw2MmE4ZGU5NzEwOGVjZTViODgxYWQxMmMiLCJhdWQiOiJ0emVXSmhhMVc1TndyVUJSQ1N3T2R0Q0dxSVE1bXpBSSIsImlhdCI6MTY1NTg4NDA0MywiZXhwIjoxNjU1OTIwMDQzfQ.fQ4LVRmMaqVRk1y5U37FCGkMz1CPMSsqOS7SSxxncpn0298pzSsH4MabbPOwzjmJ5pOJIJUgj2nHNmgLbRFH94xuWae40aENoWNxsp53UM1g9CTBGbUYj1ErxGmOQutw5yDR4ZFAjni3Lhj6s9pcvRFshNa0nDVtoOh53rz5NBfsN4kGNMUR31xyTPmlCZIbyJ2d3nR2vQv-OEbknoBQ9sBFxWwWkrTYjyZ28w6VGyAH2zC06zKSNgoMbC9GuXYoH5C8RXOu0EOcF6Q01mUABosGwOwJ02cg1DthIBssJ6BAkyegkQHupSXb5FZ45Z3Zwh16MZD_ig8oVi64-573bA&client_id=<SECRET_CLIENT_ID>&grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Ajwt-bearer&scope=openid+pib
+    headers:
+      Connection:
+      - close
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Host:
+      - accounts.dowjones.com
+      User-Agent:
+      - http.rb/5.1.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '1223'
+      Connection:
+      - close
+      Access-Control-Allow-Methods:
+      - POST, GET, OPTIONS
+      Access-Control-Allow-Origin:
+      - "*"
+      Date:
+      - Wed, 22 Jun 2022 07:47:23 GMT
+      Server:
+      - Apache
+      Set-Cookie:
+      - djcs_route=7e5f01e9-291b-4f83-931b-fc119bc8e54b; domain=.dowjones.com; path=/;
+        Expires=Sat Jun 19 07:47:23 2032; max-age=315360000;Secure; SameSite=none
+      Vary:
+      - Accept-Encoding
+      X-P-Cache-Control:
+      - no-store
+      X-P-Connection:
+      - keep-alive
+      X-P-Content-Length:
+      - '1223'
+      X-P-Content-Type:
+      - application/json; charset=utf-8
+      X-P-Date:
+      - Wed, 22 Jun 2022 07:47:23 GMT
+      X-P-P3p:
+      - CP="CAO DSP COR CURa ADMa DEVi TAIo PSAa PSDa IVDi CONi OTPi OUR OTRi BUS
+        PHY ONL UNI PUR COM NAV INT DEM CNT STA OTC"
+      X-P-Pragma:
+      - no-cache
+      X-P-Server:
+      - Microsoft-IIS/8.5
+      X-P-Via:
+      - 1.1 ec18462cf9d88c8bdb0cd5e50dbe442a.cloudfront.net (CloudFront)
+      X-P-X-Amz-Cf-Id:
+      - 5_lYlJfT5lKlqwLkg6KDNg12rR_giklC0SelFnfNOHut2e5qg--e-g==
+      X-P-X-Amz-Cf-Pop:
+      - IAD89-P2
+      X-P-X-Cache:
+      - Miss from cloudfront
+      X-P-X-Powered-By:
+      - ASP.NET
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 9b77256cb4a2caf313b1650e5e0805f8.cloudfront.net (CloudFront)
+      X-Amz-Cf-Pop:
+      - LIS50-C1
+      X-Amz-Cf-Id:
+      - PZLUnPMv75_oAyMtRBBE4AKARDB1gdf-URp8aLy34L3yXUAiSkUz0Q==
+    body:
+      encoding: UTF-8
+      string: '{"access_token":"eyJhbGciOiJSUzI1NiIsImtpZCI6IjJEN0IwQTFERkJCNzlDRDFBQjM4NzNCMTcyODMyRjkxMENEQkRBREIiLCJ0eXAiOiJKV1QifQ.eyJwaWIiOnsiYXBjIjoiUk5DIiwiY3RjIjoiUCIsIm1hc3Rlcl9hcHBfaWQiOiJ0emVXSmhhMVc1TndyVUJSQ1N3T2R0Q0dxSVE1bXpBSSIsInNlcnZpY2VfYWNjb3VudF9pZCI6IjlTRVEwMDAzMDAiLCJlbmNyeXB0ZWRfdG9rZW4iOiJJMDBfSlVZVE1OSlZIQTREQU1SU0hBWFZRV1JWSU5FR0MzTEtJSkhXRzJTWEs1UVZLTVRDRk5UVk1OTDJKVlJGT01DUk9STEhVTlNOSUpZRkEyU1pNUkFWTVUyUUdNWFVHMkRDR0IyVUdaQ0hJSkhYQTVDUUtKVUUyWkxMSlEzWEEySllGTlVEUzZLWk41SFZNNDNESlJYRUtUMzJHWlFYU1YyQ0tOWVdHSzJKSk5VVE1WWlBOQjJVUzVMVk5RWFdPVEo1STQifSwiaXNzIjoiaHR0cHM6Ly9hY2NvdW50cy5kb3dqb25lcy5jb20vb2F1dGgyL3YyIiwic3ViIjoiYXV0aDB8NjJhOGRlOTcxMDhlY2U1Yjg4MWFkMTJjIiwiYXVkIjoidHplV0poYTFXNU53clVCUkNTd09kdENHcUlRNW16QUkiLCJhenAiOiJ0emVXSmhhMVc1TndyVUJSQ1N3T2R0Q0dxSVE1bXpBSSIsImlhdCI6MTY1NTg4NDA0NCwiZXhwIjoxNjU1ODg3NjQ0fQ.SfbDxkzrH8sJveJh9cnCckCofdfGTBvwhHkpdLctlrL2lQ8KepNysE_lABkxEhGvMCRKYqNVYivGRpL-6EdCmt84ica2x9RclOEnJDfAgrA0sfXIlMF5fIBYVhbxvsxs38f08x_qCp45mQ3nZcHvT4MOHtseiduWxyR9lXiZ4JGWu0vAtoGU20rRC_5XZrLP9fYSHAZtlkhJnE2wwUdsc5jQh1gL4o2GZSxzdl-p5bY_1wxa_vuCOt2eWxqvuwYaNpDJv7eyTUwnnaLoQeJDI7hJOvZb6BekZ3kOtlOWoO1jvap2oQ6LA8IOtQKKy6a9W2Qqv2uUqYKtJrTjJ7m9Zg","token_type":"Bearer","expires_in":3600}'
+  recorded_at: Wed, 22 Jun 2022 07:47:24 GMT

--- a/spec/vcr/profile/authentication_only.yml
+++ b/spec/vcr/profile/authentication_only.yml
@@ -1,0 +1,156 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://accounts.dowjones.com/oauth2/v1/token
+    body:
+      encoding: UTF-8
+      string: client_id=<SECRET_CLIENT_ID>&connection=service-account&grant_type=password&password=<SECRET_PASSWORD>&scope=openid+service_account_id+offline_access%3A&username=<SECRET_USERNAME>&device=testdevice
+    headers:
+      Connection:
+      - close
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Host:
+      - accounts.dowjones.com
+      User-Agent:
+      - http.rb/5.0.4
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '873'
+      Connection:
+      - close
+      Access-Control-Allow-Methods:
+      - POST, GET, OPTIONS
+      Access-Control-Allow-Origin:
+      - "*"
+      Date:
+      - Wed, 02 Feb 2022 11:32:04 GMT
+      Server:
+      - Apache
+      Set-Cookie:
+      - djcs_route=f61cc21c-15cf-4329-8dfb-8742ecef3c9f; domain=.dowjones.com; path=/;
+        Expires=Sat Jan 31 11:32:04 2032; max-age=315360000;Secure; SameSite=none
+      X-P-Cache-Control:
+      - no-store
+      X-P-Connection:
+      - keep-alive
+      X-P-Content-Length:
+      - '873'
+      X-P-Content-Type:
+      - application/json; charset=utf-8
+      X-P-Date:
+      - Wed, 02 Feb 2022 11:32:04 GMT
+      X-P-P3p:
+      - CP="CAO DSP COR CURa ADMa DEVi TAIo PSAa PSDa IVDi CONi OTPi OUR OTRi BUS
+        PHY ONL UNI PUR COM NAV INT DEM CNT STA OTC"
+      X-P-Pragma:
+      - no-cache
+      X-P-Server:
+      - Microsoft-IIS/8.5
+      X-P-Via:
+      - 1.1 9c6666844f92bfc6b8685747b641abc6.cloudfront.net (CloudFront)
+      X-P-X-Amz-Cf-Id:
+      - W8QOPOiysG5ilaxD0mMuoopr8f8-5ZQ5PrBDxzA0nYkqqpD-6mdz8Q==
+      X-P-X-Amz-Cf-Pop:
+      - IAD89-P2
+      X-P-X-Cache:
+      - Miss from cloudfront
+      X-P-X-Powered-By:
+      - ASP.NET
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 eae0fbb8e97278d435febe844db04b08.cloudfront.net (CloudFront)
+      X-Amz-Cf-Pop:
+      - MAD50-C1
+      X-Amz-Cf-Id:
+      - JZmotrDwtFJBW9fvpHRZECgxAjbwlcKo0r-Nud1_p_eYTAiOqvkN1g==
+    body:
+      encoding: UTF-8
+      string: '{"id_token":"eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6Ik4wSTJRekJEUWpRM04wUkJSakJFUkRVM05qaEZNREF5T0VWRlJqWkRSVVl4TWtFMU5ERXdSUSJ9.eyJzZXJ2aWNlX2FjY291bnRfaWQiOiI5U0VRMDAwMjAwIiwiaXNzIjoiaHR0cHM6Ly9hdXRoLmFjY291bnRzLmRvd2pvbmVzLmNvbS8iLCJzdWIiOiJhdXRoMHw2MWIyNzIwZjFjM2IyMjU2ZDdlMzUyNzYiLCJhdWQiOiJlTnlIckwwQ0xmNEFtRWxnMmZmQjBkcmFmYVVPTndjRyIsImlhdCI6MTY0MzgwMTUyNCwiZXhwIjoxNjQzODM3NTI0fQ.OULF7luRnaxku7Uyf7SlRrpLOcWYe46zFzrCr2Ro_o0vR8LSVp_Xa4gaC-Cidg0_uZ0MiMp76d4tGIqXXIiw6QahzMxOP1Yi2ZIXBPpFT-5uggxMK-eRE8DeunSLGv_p1fzPtFVHR3Nd_V-NbM_hbgi8aq7yIiWWDaCuYT-6uz6-reb1gni-_hPlfytdKDIOR3P89faRfUqiLtPSjv2LATML9NR6EcxV2KLMI33vmlGNVrTw5dl44VNP1p_rXcdOPPh91MQHzsORwJc5_qWYlgfh_Pbsk8aV2AX0GfCajJ_mqRZxfs1c0H7jcVwr0AXxDmtbWPMMZn4ujeu3r9kAXA","access_token":"2DTLxVogq2wXrl9MOKoriDJoBb1QLCMK","refresh_token":"ECzTXzHHhjfdYYauHkLK8WlmrqVoDaNPM_vuGI_UI-WaJ","token_type":"bearer"}'
+  recorded_at: Wed, 02 Feb 2022 11:32:05 GMT
+- request:
+    method: post
+    uri: https://accounts.dowjones.com/oauth2/v1/token
+    body:
+      encoding: UTF-8
+      string: assertion=eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6Ik4wSTJRekJEUWpRM04wUkJSakJFUkRVM05qaEZNREF5T0VWRlJqWkRSVVl4TWtFMU5ERXdSUSJ9.eyJzZXJ2aWNlX2FjY291bnRfaWQiOiI5U0VRMDAwMjAwIiwiaXNzIjoiaHR0cHM6Ly9hdXRoLmFjY291bnRzLmRvd2pvbmVzLmNvbS8iLCJzdWIiOiJhdXRoMHw2MWIyNzIwZjFjM2IyMjU2ZDdlMzUyNzYiLCJhdWQiOiJlTnlIckwwQ0xmNEFtRWxnMmZmQjBkcmFmYVVPTndjRyIsImlhdCI6MTY0MzgwMTUyNCwiZXhwIjoxNjQzODM3NTI0fQ.OULF7luRnaxku7Uyf7SlRrpLOcWYe46zFzrCr2Ro_o0vR8LSVp_Xa4gaC-Cidg0_uZ0MiMp76d4tGIqXXIiw6QahzMxOP1Yi2ZIXBPpFT-5uggxMK-eRE8DeunSLGv_p1fzPtFVHR3Nd_V-NbM_hbgi8aq7yIiWWDaCuYT-6uz6-reb1gni-_hPlfytdKDIOR3P89faRfUqiLtPSjv2LATML9NR6EcxV2KLMI33vmlGNVrTw5dl44VNP1p_rXcdOPPh91MQHzsORwJc5_qWYlgfh_Pbsk8aV2AX0GfCajJ_mqRZxfs1c0H7jcVwr0AXxDmtbWPMMZn4ujeu3r9kAXA&client_id=<SECRET_CLIENT_ID>&grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Ajwt-bearer&scope=openid+pib
+    headers:
+      Connection:
+      - close
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Host:
+      - accounts.dowjones.com
+      User-Agent:
+      - http.rb/5.0.4
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '1223'
+      Connection:
+      - close
+      Access-Control-Allow-Methods:
+      - POST, GET, OPTIONS
+      Access-Control-Allow-Origin:
+      - "*"
+      Date:
+      - Wed, 02 Feb 2022 11:32:05 GMT
+      Server:
+      - Apache
+      Set-Cookie:
+      - djcs_route=2f136887-58db-4ffa-8fb1-0eddacf6592b; domain=.dowjones.com; path=/;
+        Expires=Sat Jan 31 11:32:05 2032; max-age=315360000;Secure; SameSite=none
+      Vary:
+      - Accept-Encoding
+      X-P-Cache-Control:
+      - no-store
+      X-P-Connection:
+      - keep-alive
+      X-P-Content-Length:
+      - '1223'
+      X-P-Content-Type:
+      - application/json; charset=utf-8
+      X-P-Date:
+      - Wed, 02 Feb 2022 11:32:05 GMT
+      X-P-P3p:
+      - CP="CAO DSP COR CURa ADMa DEVi TAIo PSAa PSDa IVDi CONi OTPi OUR OTRi BUS
+        PHY ONL UNI PUR COM NAV INT DEM CNT STA OTC"
+      X-P-Pragma:
+      - no-cache
+      X-P-Server:
+      - Microsoft-IIS/8.5
+      X-P-Via:
+      - 1.1 ec18462cf9d88c8bdb0cd5e50dbe442a.cloudfront.net (CloudFront)
+      X-P-X-Amz-Cf-Id:
+      - CxjPlg5CQularr3ia71rnFak1bOFII4WKyph58dsPWV-ffTZqeaxbA==
+      X-P-X-Amz-Cf-Pop:
+      - IAD89-P2
+      X-P-X-Cache:
+      - Miss from cloudfront
+      X-P-X-Powered-By:
+      - ASP.NET
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 02fcbf68a81897cc093ee1510fb7e93e.cloudfront.net (CloudFront)
+      X-Amz-Cf-Pop:
+      - MAD50-C1
+      X-Amz-Cf-Id:
+      - 7NDVUJIHfLf20CpLl6HBgdciJnm02JH-UfOttJIF9uzIu66p7fQhGQ==
+    body:
+      encoding: UTF-8
+      string: '{"access_token":"eyJhbGciOiJSUzI1NiIsImtpZCI6IjJEN0IwQTFERkJCNzlDRDFBQjM4NzNCMTcyODMyRjkxMENEQkRBREIiLCJ0eXAiOiJKV1QifQ.eyJwaWIiOnsiYXBjIjoiUk5DIiwiY3RjIjoiUCIsIm1hc3Rlcl9hcHBfaWQiOiJlTnlIckwwQ0xmNEFtRWxnMmZmQjBkcmFmYVVPTndjRyIsInNlcnZpY2VfYWNjb3VudF9pZCI6IjlTRVEwMDAyMDAiLCJlbmNyeXB0ZWRfdG9rZW4iOiJJMDBfSlVZVE1OQlRHNDRUUU5SU0hBWFdFU1RZTUkzR09VM1lMQTJWSzIzUkpWVVhFVUNJTk5MVTRVWlBLRVpFNEwzSFBKTEVZVjJSRk5JSENSVFZHNVRFWTJMWE41SEZJUjNOR1ZJRU82VE9NUktYTzJaUE1OVkhPT0xaSU5BWE9aWllPWVhXTVpDWkhGWlZRVVNTTlZNV1NURFVHUVhYSVVSVElWUlVTTFpSTTVKV1lNU0pPUk1HTVRDT01aRERDT0I1STQifSwiaXNzIjoiaHR0cHM6Ly9hY2NvdW50cy5kb3dqb25lcy5jb20vb2F1dGgyL3YyIiwic3ViIjoiYXV0aDB8NjFiMjcyMGYxYzNiMjI1NmQ3ZTM1Mjc2IiwiYXVkIjoiZU55SHJMMENMZjRBbUVsZzJmZkIwZHJhZmFVT053Y0ciLCJhenAiOiJlTnlIckwwQ0xmNEFtRWxnMmZmQjBkcmFmYVVPTndjRyIsImlhdCI6MTY0MzgwMTUyNiwiZXhwIjoxNjQzODA1MTI2fQ.Zfu9PDWyRdrrqcwdZmUoRjcE1EHJH8IyGVfGVylYiYp5x1csV3v5RxDTKbxAqoQAC_ItzPoDf_cAtSQIGR5XseQPckhgNqhCbD6IuiAFYZaCjEaIWVn8GEGF7h4lMNapanB4aLqhcY9eNj_NBu8oHR-V18aNjYLPJkJzojpAgG7rXt1mc91Q3B5LE4YYBiNZL2bR_HSxZL-PGoV4DuCDtIDvc7cuOKDPeKPgM0t8z8GIv_yD5pL1iSfz76RXjHFQDkx24hSrB3fuB9qvyTDhTxoGsg3C7NucWmgniGvfXiDKRoHM0aPVKRjpoIGINCeQ_0PGvjNzbUCBpOLtaXPCtw","token_type":"Bearer","expires_in":3600}'
+  recorded_at: Wed, 02 Feb 2022 11:32:06 GMT

--- a/spec/vcr/search/authentication_only.yml
+++ b/spec/vcr/search/authentication_only.yml
@@ -1,0 +1,156 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://accounts.dowjones.com/oauth2/v1/token
+    body:
+      encoding: UTF-8
+      string: client_id=<SECRET_CLIENT_ID>&connection=service-account&grant_type=password&password=<SECRET_PASSWORD>&scope=openid+service_account_id+offline_access%3A&username=<SECRET_USERNAME>&device=testdevice
+    headers:
+      Connection:
+      - close
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Host:
+      - accounts.dowjones.com
+      User-Agent:
+      - http.rb/5.0.4
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '873'
+      Connection:
+      - close
+      Access-Control-Allow-Methods:
+      - POST, GET, OPTIONS
+      Access-Control-Allow-Origin:
+      - "*"
+      Date:
+      - Mon, 23 May 2022 15:38:00 GMT
+      Server:
+      - Apache
+      Set-Cookie:
+      - djcs_route=e7fa33bd-07e1-452c-8be4-e2485098b52d; domain=.dowjones.com; path=/;
+        Expires=Thu May 20 15:38:00 2032; max-age=315360000;Secure; SameSite=none
+      X-P-Cache-Control:
+      - no-store
+      X-P-Connection:
+      - keep-alive
+      X-P-Content-Length:
+      - '873'
+      X-P-Content-Type:
+      - application/json; charset=utf-8
+      X-P-Date:
+      - Mon, 23 May 2022 15:38:00 GMT
+      X-P-P3p:
+      - CP="CAO DSP COR CURa ADMa DEVi TAIo PSAa PSDa IVDi CONi OTPi OUR OTRi BUS
+        PHY ONL UNI PUR COM NAV INT DEM CNT STA OTC"
+      X-P-Pragma:
+      - no-cache
+      X-P-Server:
+      - Microsoft-IIS/8.5
+      X-P-Via:
+      - 1.1 749e1450fdc7cac18bb91a34e80053aa.cloudfront.net (CloudFront)
+      X-P-X-Amz-Cf-Id:
+      - BZxGJS-DjxJjddizL7yxx6V8-awZijzI8hJh_xBfjbAzHsw7Kenf-A==
+      X-P-X-Amz-Cf-Pop:
+      - IAD50-C2
+      X-P-X-Cache:
+      - Miss from cloudfront
+      X-P-X-Powered-By:
+      - ASP.NET
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 3d4bc9f760d271ea8c82b4a4027b2f92.cloudfront.net (CloudFront)
+      X-Amz-Cf-Pop:
+      - MAD51-C2
+      X-Amz-Cf-Id:
+      - 7jS4QVQDErFcYoFIp41mCqhjXZ_1q6qgDcNHFMbwnLbq_XQKdEcsIw==
+    body:
+      encoding: UTF-8
+      string: '{"id_token":"eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6Ik4wSTJRekJEUWpRM04wUkJSakJFUkRVM05qaEZNREF5T0VWRlJqWkRSVVl4TWtFMU5ERXdSUSJ9.eyJzZXJ2aWNlX2FjY291bnRfaWQiOiI5U0VRMDAwMjAwIiwiaXNzIjoiaHR0cHM6Ly9hdXRoLmFjY291bnRzLmRvd2pvbmVzLmNvbS8iLCJzdWIiOiJhdXRoMHw2MWIyNzIwZjFjM2IyMjU2ZDdlMzUyNzYiLCJhdWQiOiJlTnlIckwwQ0xmNEFtRWxnMmZmQjBkcmFmYVVPTndjRyIsImlhdCI6MTY1MzMyMDI4MSwiZXhwIjoxNjUzMzU2MjgxfQ.o4a4151n0wsAewyEV8Wbql2yxxdKawoUvvR6be2GA40Z4RI6Q6uBRpURJekxa-K8CjFN37R0z7CUOoZaQPr07e3SXf5z53H5RaHF9bVe-Gh8senZ1N5dU7fC0-CdqB-ChGg-UMaeIZ31dL6241dT2LiNoir5CljZz0SQQ5K9JPKUxvL1C5G2eE8U-oXVSS8ZDOR3bxTq7hHMjNqrPzzju466VWpdNfr_G8f7o75nFn75uYTgvq5WcIa6nnSXK1Vbv1cfiOanb4Rg789n0iNkRR3POX04Z6cPDchddmucuEvaOKhG5YOM1PQws1Z4A6Cw2uBAsN7YfMFcrxcPx8gT8Q","access_token":"COBMdOw9Q8E0xejTJgZAmtcDWfaJ0XGO","refresh_token":"XpQwZxvr1NQFBDaESzVwqpMnMgAyFo68r-6A6GeTp7932","token_type":"bearer"}'
+  recorded_at: Mon, 23 May 2022 15:38:01 GMT
+- request:
+    method: post
+    uri: https://accounts.dowjones.com/oauth2/v1/token
+    body:
+      encoding: UTF-8
+      string: assertion=eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6Ik4wSTJRekJEUWpRM04wUkJSakJFUkRVM05qaEZNREF5T0VWRlJqWkRSVVl4TWtFMU5ERXdSUSJ9.eyJzZXJ2aWNlX2FjY291bnRfaWQiOiI5U0VRMDAwMjAwIiwiaXNzIjoiaHR0cHM6Ly9hdXRoLmFjY291bnRzLmRvd2pvbmVzLmNvbS8iLCJzdWIiOiJhdXRoMHw2MWIyNzIwZjFjM2IyMjU2ZDdlMzUyNzYiLCJhdWQiOiJlTnlIckwwQ0xmNEFtRWxnMmZmQjBkcmFmYVVPTndjRyIsImlhdCI6MTY1MzMyMDI4MSwiZXhwIjoxNjUzMzU2MjgxfQ.o4a4151n0wsAewyEV8Wbql2yxxdKawoUvvR6be2GA40Z4RI6Q6uBRpURJekxa-K8CjFN37R0z7CUOoZaQPr07e3SXf5z53H5RaHF9bVe-Gh8senZ1N5dU7fC0-CdqB-ChGg-UMaeIZ31dL6241dT2LiNoir5CljZz0SQQ5K9JPKUxvL1C5G2eE8U-oXVSS8ZDOR3bxTq7hHMjNqrPzzju466VWpdNfr_G8f7o75nFn75uYTgvq5WcIa6nnSXK1Vbv1cfiOanb4Rg789n0iNkRR3POX04Z6cPDchddmucuEvaOKhG5YOM1PQws1Z4A6Cw2uBAsN7YfMFcrxcPx8gT8Q&client_id=<SECRET_CLIENT_ID>&grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Ajwt-bearer&scope=openid+pib
+    headers:
+      Connection:
+      - close
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Host:
+      - accounts.dowjones.com
+      User-Agent:
+      - http.rb/5.0.4
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '1223'
+      Connection:
+      - close
+      Access-Control-Allow-Methods:
+      - POST, GET, OPTIONS
+      Access-Control-Allow-Origin:
+      - "*"
+      Date:
+      - Mon, 23 May 2022 15:38:01 GMT
+      Server:
+      - Apache
+      Set-Cookie:
+      - djcs_route=bc4142b7-6ca9-4943-b5e3-794721813fcc; domain=.dowjones.com; path=/;
+        Expires=Thu May 20 15:38:01 2032; max-age=315360000;Secure; SameSite=none
+      Vary:
+      - Accept-Encoding
+      X-P-Cache-Control:
+      - no-store
+      X-P-Connection:
+      - keep-alive
+      X-P-Content-Length:
+      - '1223'
+      X-P-Content-Type:
+      - application/json; charset=utf-8
+      X-P-Date:
+      - Mon, 23 May 2022 15:38:01 GMT
+      X-P-P3p:
+      - CP="CAO DSP COR CURa ADMa DEVi TAIo PSAa PSDa IVDi CONi OTPi OUR OTRi BUS
+        PHY ONL UNI PUR COM NAV INT DEM CNT STA OTC"
+      X-P-Pragma:
+      - no-cache
+      X-P-Server:
+      - Microsoft-IIS/8.5
+      X-P-Via:
+      - 1.1 b9c7ee7ef5bcece32a3a0ac817ab1f96.cloudfront.net (CloudFront)
+      X-P-X-Amz-Cf-Id:
+      - iaCJjU_qLH9rAIfPtVRjX7VB-E1Pi08oefcv8SEUUOM35329om3EIQ==
+      X-P-X-Amz-Cf-Pop:
+      - IAD66-C1
+      X-P-X-Cache:
+      - Miss from cloudfront
+      X-P-X-Powered-By:
+      - ASP.NET
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 3a040ac81c3e03a31883d4bf85a17866.cloudfront.net (CloudFront)
+      X-Amz-Cf-Pop:
+      - MAD51-C2
+      X-Amz-Cf-Id:
+      - fcZozCvQE0af5NbhHPJhcOOyBLq4vOaP_gP5nDq80rinim8ZtNk7-w==
+    body:
+      encoding: UTF-8
+      string: '{"access_token":"eyJhbGciOiJSUzI1NiIsImtpZCI6IjJEN0IwQTFERkJCNzlDRDFBQjM4NzNCMTcyODMyRjkxMENEQkRBREIiLCJ0eXAiOiJKV1QifQ.eyJwaWIiOnsiYXBjIjoiUk5DIiwiY3RjIjoiUCIsIm1hc3Rlcl9hcHBfaWQiOiJlTnlIckwwQ0xmNEFtRWxnMmZmQjBkcmFmYVVPTndjRyIsInNlcnZpY2VfYWNjb3VudF9pZCI6IjlTRVEwMDAyMDAiLCJlbmNyeXB0ZWRfdG9rZW4iOiJJMDBfSlVZVE1OSlRHTVlUT01CU0hBWFVXMlRIT1JWVVFWTFNONTJGTTUyUklWS1dVMjJCTlpLVU1ZWlZNSTRFNFVUMklWNFhTMlNNT0pLRU9PTFBHSkpYRTVMTUtCRkhPMkNMT1ZRVEVMM1RNWlhHSVYyTElaRkVVUkNJTlJFWEtTWlVGTlNYTzQzTktOR1hNS1pWS1ozVElXRFZOVkdVQ1pLR1BGSkRBTUJRR0JGVk1UQlpPTk1XS1dLU05SWUhTT0I1STQifSwiaXNzIjoiaHR0cHM6Ly9hY2NvdW50cy5kb3dqb25lcy5jb20vb2F1dGgyL3YyIiwic3ViIjoiYXV0aDB8NjFiMjcyMGYxYzNiMjI1NmQ3ZTM1Mjc2IiwiYXVkIjoiZU55SHJMMENMZjRBbUVsZzJmZkIwZHJhZmFVT053Y0ciLCJhenAiOiJlTnlIckwwQ0xmNEFtRWxnMmZmQjBkcmFmYVVPTndjRyIsImlhdCI6MTY1MzMyMDI4MiwiZXhwIjoxNjUzMzIzODgyfQ.TuX-bDij1w-D8ANRRI5vQSEtia6OBzaQyD33SwgJ99sve-PEQFeu16_wNk4YW_Ziyimx-BCME_NXKU0M80J81LZzJwzLvYP8jCB-DTSaMjnF-XzEsl0VjnS18Vd8sWbbU1f9xW6njqGu-4nLIkYkzSLkuuPgPabuXqq0eAwUURA3F_7iTcZ0O25HDmSO8HHx8eNNtR5NjahbrnD27Q2bm89iZ1ZbGeQ89y1YHDMTOd_1mskXRBERlUzneoR6lso0CX1fsEwR3B2RSz-geOREfMIO5xVDPiG9oCSOT0ERapWGg_VOWhS4Ryev3Hp-ZWLbv6N_m7c8okZ0Zd10QbCEDA","token_type":"Bearer","expires_in":3600}'
+  recorded_at: Mon, 23 May 2022 15:38:02 GMT


### PR DESCRIPTION
### What is the goal?

Factiva gem has to raise `HTTP::TimeoutError` when connection timed out so it can be handled by the circuit-breaker.

### References

* **Issue:** https://sequra.atlassian.net/browse/RT-749

### How is it being implemented?

Re-raise `HTTP::TimeoutError` while handling other errors and converting them to `Failure`

### Opportunistic refactorings

Added `Factiva::Client` class to call different API endpoints and handle authentication

### Caveats

We should update Circuit Breaker configuration in Timon right after deploying this PR

### How is it tested?

Automatic tests

### How is it going to be deployed?

Release new version