### PR TITLE
fix: Add missing stub for bulk_create_associations

### DIFF
--- a/lib/factiva/monitoring.rb
+++ b/lib/factiva/monitoring.rb
@@ -103,6 +103,7 @@ module Factiva
     class MockedRequest
       attr_reader :stubbed_create_case,
       :stubbed_create_association,
+      :stubbed_bulk_create_associations,
       :stubbed_update_association,
       :stubbed_delete_association,
       :stubbed_add_association_to_case,
@@ -114,6 +115,7 @@ module Factiva
 
       def initialize(stubbed_create_case,
         stubbed_create_association,
+        stubbed_bulk_create_associations,
         stubbed_update_association,
         stubbed_delete_association,
         stubbed_add_association_to_case,
@@ -125,6 +127,7 @@ module Factiva
       )
         @stubbed_create_case = stubbed_create_case
         @stubbed_create_association = stubbed_create_association
+        @stubbed_create_association = stubbed_bulk_create_associations
         @stubbed_update_association = stubbed_update_association
         @stubbed_delete_association = stubbed_delete_association
         @stubbed_add_association_to_case = stubbed_add_association_to_case


### PR DESCRIPTION


### What is the goal?

Add missing stub for `bulk_create_association`.

### References

* **Related pull-requests:** https://github.com/sequra/simba/pull/10470


### Does it affect (changes or update) any sensitive data?

No

### How is it tested?

Manual tests

### How is it going to be deployed?

Standard deployment