### PR TITLE
[SUPS-1630] Handle 'errors' key in API error responses

### DIFF
--- a/lib/factiva/monitoring.rb
+++ b/lib/factiva/monitoring.rb
@@ -367,7 +367,8 @@ module Factiva
         if response.status.success?
           Success(response_body)
         else
-          Failure({ code: response.code, error: response_body["error"] }.to_s)
+          error_message = response_body["error"] || response_body["errors"]
+          Failure({ code: response.code, error: error_message }.to_s)
         end
       rescue HTTP::TimeoutError
         # This error should be handled before HTTP::Error which is a superclass of HTTP::TimeoutError

--- a/lib/factiva/request.rb
+++ b/lib/factiva/request.rb
@@ -118,7 +118,8 @@ module Factiva
         if response.status.success?
           Success(response_body)
         else
-          Failure({ code: response.code, error: response_body["error"] }.to_s)
+          error_message = response_body["error"] || response_body["errors"]
+          Failure({ code: response.code, error: error_message }.to_s)
         end
       rescue HTTP::TimeoutError
         # This error should be handled before HTTP::Error which is a superclass of HTTP::TimeoutError

--- a/spec/factiva/monitoring_spec.rb
+++ b/spec/factiva/monitoring_spec.rb
@@ -161,10 +161,13 @@ module Factiva
       end
 
       context "when factiva returns an error", vcr: "monitoring/delete_association_invalid" do
-        it "raises a Factiva::RequestError" do
+        it "raises a Factiva::RequestError with error details from the 'errors' key" do
           expect {
             subject.delete_association(association_id: "invalid_id")
-          }.to raise_error(Factiva::RequestError)
+          }.to raise_error(Factiva::RequestError) { |error|
+            expect(error.message).to include("404")
+            expect(error.message).to include("Association with id invalid_id not found.")
+          }
         end
       end
     end
@@ -403,10 +406,13 @@ module Factiva
           }
         ] }
 
-        it "raises a Factiva::RequestError" do
+        it "raises a Factiva::RequestError with error details from the 'errors' key" do
           expect {
             response
-          }.to raise_error(Factiva::RequestError)
+          }.to raise_error(Factiva::RequestError) { |error|
+            expect(error.message).to include("400")
+            expect(error.message).to include("match not found")
+          }
         end
       end
     end


### PR DESCRIPTION
### What is the goal?

Fix error details being silently lost when the Factiva API returns a non-successful HTTP response with an `"errors"` key (plural) instead of `"error"` (singular). Previously, the error message propagated to callers was `{code: 400, error: nil}`, providing no visibility into what went wrong.

### References
* **Issue:** https://sequra.atlassian.net/browse/SUPS-1630

### How is it being implemented?

In `Factiva::Monitoring#make_request` and `Factiva::Request#make_request`:

falls back to `response_body["errors"]` when `response_body["error"]` is absent.

### Opportunistic refactorings

None.

### Caveats

The `"error"` key takes precedence over `"errors"`. In practice the API appears to use one or the other consistently per endpoint, so this should not cause any ambiguity.

It looks like most, if not all the endpoints (apart from the ones related to authentication) would return 'errors' instead of 'error', so potentially this could be transitioned entirely to just use 'errors' without any fallback.

That said, keeping the fallback doesn't hurt and makes the code resilient to any inconsistencies in undocumented endpoints while avoiding any potential regressions.

### Does it affect (changes or update) any sensitive data?

No. This change only affects error message formatting; no data is stored or transmitted differently.

### How is it tested?

RSpec

### How is it going to be deployed?

Standard deployment