### PR TITLE
feat: add status_code and error_body attributes to RequestError

### DIFF
--- a/lib/factiva/errors.rb
+++ b/lib/factiva/errors.rb
@@ -1,5 +1,23 @@
 module Factiva
   class Error < StandardError; end
-  class RequestError < Error; end
+
+  class RequestError < Error
+    attr_reader :status_code, :error_body
+
+    def self.from_response(error)
+      if error.is_a?(Hash)
+        new(error.to_s, status_code: error[:code], error_body: error[:error])
+      else
+        new(error.to_s)
+      end
+    end
+
+    def initialize(message = nil, status_code: nil, error_body: nil)
+      @status_code = status_code
+      @error_body = error_body
+      super(message)
+    end
+  end
+
   class TimeoutError < Error; end
 end

--- a/lib/factiva/monitoring.rb
+++ b/lib/factiva/monitoring.rb
@@ -199,7 +199,7 @@ module Factiva
       # If the request fails auth is reset and the request retried
       post(create_case_url, params)
         .or       { set_auth; post(create_case_url, params) }
-        .value_or { |error| raise RequestError.new(error) }
+        .value_or { |error| raise RequestError.from_response(error) }
     end
 
     def create_association(first_name:, last_name:, birth_year:, external_id:, nin:, country_code:)
@@ -216,14 +216,14 @@ module Factiva
       # If the request fails auth is reset and the request retried
       post(associations_url, params)
         .or       { set_auth; post(associations_url, params) }
-        .value_or { |error| raise RequestError.new(error) }
+        .value_or { |error| raise RequestError.from_response(error) }
     end
 
     def list_associations(offset: 0, limit: 100, filter_correlated: false)
       # If the request fails auth is reset and the request retried
       get(list_associations_url(offset: offset, limit: limit, filter_correlated: filter_correlated))
         .or       { set_auth; get(list_associations_url(offset: offset, limit: limit, filter_correlated: filter_correlated)) }
-        .value_or { |error| raise RequestError.new(error) }
+        .value_or { |error| raise RequestError.from_response(error) }
     end
 
     def bulk_create_associations(case_id:, associations:)
@@ -233,7 +233,7 @@ module Factiva
 
       post(bulk_create_associations_url(case_id), params)
         .or       { set_auth; post(bulk_create_associations_url(case_id), params) }
-        .value_or { |error| raise RequestError.new(error) }
+        .value_or { |error| raise RequestError.from_response(error) }
     end
 
     def update_association(association_id:, params:)
@@ -251,7 +251,7 @@ module Factiva
       # If the request fails auth is reset and the request retried
       patch(url, params)
         .or       { set_auth; patch(url, params) }
-        .value_or { |error| raise RequestError.new(error) }
+        .value_or { |error| raise RequestError.from_response(error) }
     end
 
     def delete_association(association_id:)
@@ -260,7 +260,7 @@ module Factiva
       # If the request fails auth is reset and the request retried
       delete(url)
         .or       { set_auth; delete(url) }
-        .value_or { |error| raise RequestError.new(error) }
+        .value_or { |error| raise RequestError.from_response(error) }
     end
 
     def add_association_to_case(case_id:, association_id:)
@@ -272,7 +272,7 @@ module Factiva
       # If the request fails auth is reset and the request retried
       post(case_associations_url(case_id), params)
         .or       { set_auth; post(case_associations_url(case_id), params) }
-        .value_or { |error| raise RequestError.new(error) }
+        .value_or { |error| raise RequestError.from_response(error) }
     end
 
     def remove_association_from_case(case_id:, association_id:)
@@ -281,7 +281,7 @@ module Factiva
       # If the request fails auth is reset and the request retried
       delete(url)
         .or       { set_auth; delete(url) }
-        .value_or { |error| raise RequestError.new(error) }
+        .value_or { |error| raise RequestError.from_response(error) }
     end
 
     def get_matches(case_id:, offset: 0, limit: 100, has_alerts: "any", is_match_valid: "any")
@@ -296,7 +296,7 @@ module Factiva
       # If the request fails auth is reset and the request retried
       get(url)
         .or       { set_auth; get(url) }
-        .value_or { |error| raise RequestError.new(error) }
+        .value_or { |error| raise RequestError.from_response(error) }
     end
 
     def log_decision(case_id:, match_id:, comment:, state:, risk_rating:)
@@ -308,7 +308,7 @@ module Factiva
       # If the request fails auth is reset and the request retried
       patch(log_decision_url(case_id, match_id), params)
         .or       { set_auth; patch(log_decision_url(case_id, match_id), params) }
-        .value_or { |error| raise RequestError.new(error) }
+        .value_or { |error| raise RequestError.from_response(error) }
     end
 
     def update_matches(case_id:, matches_data:)
@@ -322,7 +322,7 @@ module Factiva
       # If the request fails auth is reset and the request retried
       patch(url, params, headers)
         .or       { set_auth; patch(url, params, headers) }
-        .value_or { |error| raise RequestError.new(error) }
+        .value_or { |error| raise RequestError.from_response(error) }
     end
 
   private
@@ -368,7 +368,7 @@ module Factiva
           Success(response_body)
         else
           error_message = response_body["error"] || response_body["errors"]
-          Failure({ code: response.code, error: error_message }.to_s)
+          Failure({ code: response.code, error: error_message })
         end
       rescue HTTP::TimeoutError
         # This error should be handled before HTTP::Error which is a superclass of HTTP::TimeoutError

--- a/lib/factiva/request.rb
+++ b/lib/factiva/request.rb
@@ -75,7 +75,7 @@ module Factiva
       # If the request fails auth is reset and the request retried
       post(search_url, params)
         .or       { set_auth; post(search_url, params) }
-        .value_or { |error| raise RequestError.new(error) }
+        .value_or { |error| raise RequestError.from_response(error) }
     end
 
     def profile(profile_id)
@@ -84,7 +84,7 @@ module Factiva
       # If the request fails auth is reset and the request retried
       get(url)
         .or       { set_auth; get(url) }
-        .value_or { |error| raise RequestError.new(error) }
+        .value_or { |error| raise RequestError.from_response(error) }
     end
 
   private
@@ -119,7 +119,7 @@ module Factiva
           Success(response_body)
         else
           error_message = response_body["error"] || response_body["errors"]
-          Failure({ code: response.code, error: error_message }.to_s)
+          Failure({ code: response.code, error: error_message })
         end
       rescue HTTP::TimeoutError
         # This error should be handled before HTTP::Error which is a superclass of HTTP::TimeoutError

--- a/spec/factiva/monitoring_spec.rb
+++ b/spec/factiva/monitoring_spec.rb
@@ -167,6 +167,9 @@ module Factiva
           }.to raise_error(Factiva::RequestError) { |error|
             expect(error.message).to include("404")
             expect(error.message).to include("Association with id invalid_id not found.")
+            expect(error.status_code).to eq(404)
+            expect(error.error_body).to be_an(Array)
+            expect(error.error_body.first["detail"]).to include("Association with id invalid_id not found.")
           }
         end
       end
@@ -412,6 +415,8 @@ module Factiva
           }.to raise_error(Factiva::RequestError) { |error|
             expect(error.message).to include("400")
             expect(error.message).to include("match not found")
+            expect(error.status_code).to eq(400)
+            expect(error.error_body).to be_an(Array)
           }
         end
       end


### PR DESCRIPTION
### What is the goal?

Add structured `status_code` and `error_body` attributes to `Factiva::RequestError` so consumers can access error details directly without parsing the stringified message string.

Previously `RequestError` only carried a stringified Ruby hash as its message (e.g. `"{:code=>400, :error=>[...]}"`) forcing callers to parse it back to programmatically extract details if needed. You can see [this related Simba PR](https://github.com/sequra/simba/pull/18426) for more details. This change exposes `error.status_code` and `error.error_body` as first-class attributes.

### References
* **Issue:** [SUPS-1630](https://sequra.atlassian.net/browse/SUPS-1630)
* **Related pull-requests:** 
#46
https://github.com/sequra/simba/pull/18426

### How is it being implemented?

**`lib/factiva/errors.rb`** — Expand `RequestError` with:
- `status_code` reader (HTTP status code integer, `nil` for connection/parse errors)
- `error_body` reader (parsed error array/hash from response JSON, `nil` when not applicable)
- `RequestError.from_response(error)` factory: populates both attributes when given a hash Failure, falls back to `new(error.to_s)` for string Failures (connection errors, JSON parse errors)
- Constructor extended with optional keyword args `status_code:` and `error_body:` (default `nil`) — positional `message` arg still works

**`lib/factiva/monitoring.rb`** and **`lib/factiva/request.rb`**:
- `make_request` Failure now passes the hash directly: `Failure({ code: response.code, error: error_message })` — removed `.to_s`
- All 13 `.value_or` blocks updated from `RequestError.new(error)` to `RequestError.from_response(error)`

### Opportunistic refactorings

None.

### Caveats

Fully backward-compatible. Existing callers are unaffected:

| Existing usage | Why it still works |
|---|---|
| `RequestError.new("msg")` | Positional `message` arg unchanged |
| `rescue Factiva::Error => e` | Same class hierarchy |
| `e.message` | `from_response` passes `error.to_s` — same stringified format as before |
| `e.full_message` | Inherited from `StandardError` |

New attributes return `nil` when not set. Repos using this gem can adopt `status_code` / `error_body` at their own pace without any forced changes.

### Does it affect (changes or update) any sensitive data?

No.

### How is it tested?

RSpec

### How is it going to be deployed?

Standard deployment. Merge to `master` with a `feat:` conventional commit to trigger an automatic minor release.


[SUPS-1630]: https://sequra.atlassian.net/browse/SUPS-1630?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ