### PR TITLE
feat: allow per-call timeout override on Monitoring.list_associations

### DIFF
--- a/lib/factiva/monitoring.rb
+++ b/lib/factiva/monitoring.rb
@@ -219,10 +219,12 @@ module Factiva
         .value_or { |error| raise RequestError.from_response(error) }
     end
 
-    def list_associations(offset: 0, limit: 100, filter_correlated: false)
+    def list_associations(offset: 0, limit: 100, filter_correlated: false, timeout: nil)
+      url = list_associations_url(offset: offset, limit: limit, filter_correlated: filter_correlated)
+
       # If the request fails auth is reset and the request retried
-      get(list_associations_url(offset: offset, limit: limit, filter_correlated: filter_correlated))
-        .or       { set_auth; get(list_associations_url(offset: offset, limit: limit, filter_correlated: filter_correlated)) }
+      get(url, timeout: timeout)
+        .or       { set_auth; get(url, timeout: timeout) }
         .value_or { |error| raise RequestError.from_response(error) }
     end
 
@@ -347,18 +349,18 @@ module Factiva
       make_request(:patch, url, params, headers)
     end
 
-    def get(url)
-      make_request(:get, url)
+    def get(url, timeout: nil)
+      make_request(:get, url, nil, {}, timeout)
     end
 
-    def make_request(http_method, url, params = nil, headers = {})
+    def make_request(http_method, url, params = nil, headers = {}, timeout = nil)
       http_params = [http_method, url, params].compact
 
       begin
         response = HTTP
           .headers(accept: headers.fetch(:accept, DEFAULT_CONTENT_TYPE))
           .headers("Content-Type" => headers.fetch(:content_type, DEFAULT_CONTENT_TYPE))
-          .timeout(config.timeout)
+          .timeout(timeout || config.timeout)
           .auth("Bearer #{auth.token}")
           .send(*http_params)
 

--- a/spec/factiva/monitoring_spec.rb
+++ b/spec/factiva/monitoring_spec.rb
@@ -59,6 +59,34 @@ module Factiva
           )
         end
       end
+
+      context "with a timeout override", vcr: "monitoring/list_associations" do
+        it "passes the override to the HTTP client" do
+          timeouts_used = []
+          allow_any_instance_of(HTTP::Client).to receive(:timeout).and_wrap_original do |original, value|
+            timeouts_used << value
+            original.call(value)
+          end
+
+          subject.list_associations(timeout: 42)
+
+          expect(timeouts_used).to include(42)
+        end
+      end
+
+      context "without a timeout override", vcr: "monitoring/list_associations" do
+        it "falls back to config.timeout" do
+          timeouts_used = []
+          allow_any_instance_of(HTTP::Client).to receive(:timeout).and_wrap_original do |original, value|
+            timeouts_used << value
+            original.call(value)
+          end
+
+          subject.list_associations
+
+          expect(timeouts_used).to include(Factiva.configuration(Factiva::MONITORING_API_ACCOUNT).timeout)
+        end
+      end
     end
 
     describe "#create_association" do


### PR DESCRIPTION
### What is the goal?

Allow callers of `Factiva::Monitoring.list_associations` to override the HTTP timeout on a per-call basis.

The monitoring config currently defines a single global `config.timeout` (Simba sets it to `7` seconds). Dow Jones' `risk-entity-screening-associations` endpoint regularly takes ~10 seconds to respond, so the global setting is too low for this one request, while still being appropriate for the rest of the monitoring API calls. Raising the global timeout would slow down every other call's failure detection. The fix is to expose a per-call override so Simba (and any other consumer) can bump the timeout only for `list_associations`.

### References

* **Issue:** https://sequra.atlassian.net/browse/SUPS-1737

### How is it being implemented?

`Factiva::Monitoring.list_associations` now accepts an optional `timeout:` keyword argument. When omitted, behaviour is unchanged: the request still uses `config.timeout` from the monitoring account configuration.

The kwarg is threaded through the existing private wrappers:

* `list_associations(..., timeout: nil)` → passes `timeout` into both `get(url, timeout: ...)` calls (initial request + retry after `set_auth`)
* `get(url, timeout: nil)` → forwards as the 5th positional arg of `make_request`
* `make_request(http_method, url, params = nil, headers = {}, timeout = nil)` → uses `timeout || config.timeout` when building the HTTP chain

The kwarg is intentionally only exposed on `list_associations` for now. Other monitoring methods keep their existing signature. `make_request` is generic enough that exposing the override on additional methods later is a one-liner.

Example usage from Simba:

```ruby
Factiva::Monitoring.list_associations(
  offset: 0,
  limit: 10,
  filter_correlated: false,
  timeout: 30
)
```

### Opportunistic refactorings

Extracted the duplicated `list_associations_url(...)` call inside `list_associations` into a local variable, since it was being built twice (initial + retry).

### Caveats

* The `Stubbed#list_associations(**args)` mock already splats all kwargs, so passing `timeout:` through stubs is silently accepted with no behaviour change.

### Does it affect (changes or update) any sensitive data?

No.

### How is it tested?

RSpec

### How is it going to be deployed?

Standard deployment. A `feat:` conventional commit triggers `release-please` to cut a new minor version (`0.16.0`). Once released, Simba bumps the `factiva-api-client` reference in its Gemfile and updates the call site to pass `timeout:` explicitly.
